### PR TITLE
Return full (i.e. not sparse) palettes for all ROL files

### DIFF
--- a/games/game-nomad.js
+++ b/games/game-nomad.js
@@ -575,7 +575,8 @@ export default class Game_Nomad extends Game {
 					// Use GAME.PAL if the image requires it;
 					// otherwise use backg.pal
 					if (gamePalImages.includes(index)) {
-						rolImg.palette = gamePal;
+						const fullGamePal = Object.assign([], paletteVGA256(), gamePal);
+						rolImg.palette = fullGamePal;
 
 					} else {
 						const palContent = {


### PR DESCRIPTION
The Nomad support in gameinfojs was attempting to return certain `.rol` files after applying only a sparse palette to their Image container. This caused the studiojs interface to throw an exception when opening `stamproll.shipst` or `stamproll.shp`.

This fix involves overlaying the `GAME.PAL` sparse palette on top of the default 256-color VGA palette.